### PR TITLE
[LGTM]グループメンバー検索のインクリメンタルサーチ化

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -56,7 +56,7 @@ $(function(){
       var html = buildHTML(data);
       $(".messages").append(html)
       $("form")[0].reset()
-      $('submit').prop('disabled', false)
+      $('.form__box--submit-btn').prop('disabled', false)
       $(".messages").animate({"scrollTop": "100000px"})
     })
 

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,79 @@
+$(function(){
+
+  var user_list = $("#user-search-result")
+
+  function appendUser(user){
+    var html =`
+                <div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user.user_name}</p>
+                  <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.user_id}" data-user-name="${user.user_name}">追加</a>
+                </div>
+              `
+    user_list.append(html)
+  }
+
+  function appendNoUser(user){
+    var html = `
+                <div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user}</p>
+                </div>
+                `
+
+    user_list.append(html)
+  }
+
+  var member_list = $(".chat-group-users")
+
+  function appendMember(user){
+    var html = `
+                <div class='chat-group-user clearfix js-chat-member' id='chat-group-user-${user.user_id}'>
+                  <input name='group[user_ids][]' type='hidden' value='${user.user_id}'>
+                  <p class='chat-group-user__name'>${user.user_name}</p>
+                  <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+                </div>
+                `
+    member_list.append(html)
+  }
+
+  $("#user-search-field").on("input",function(){
+    var input = $("#user-search-field").val();
+
+    $.ajax({
+      type: "GET",
+      url: "/users/",
+      data: { keyword: input },
+      dataType: "json"
+    })
+
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0 ) {
+        users.forEach(function(user){
+          appendUser(user);
+        })
+      } else {
+        appendNoUser("一致するユーザーはいません")
+      }
+    })
+    .fail(function(){
+      alert("ユーザー検索に失敗しました")
+    })
+
+  })
+
+  var user = {}
+
+  $("#user-search-result").on("click",".user-search-add",function(){
+    $(this).parent().remove();
+    var user_id = $(this).attr("data-user-id");
+    var user_name = $(this).attr("data-user-name");
+    user["user_id"] = user_id
+    user["user_name"] = user_name
+    appendMember(user)
+  })
+
+  $(".chat-group-form__field").on("click",".chat-group-user__btn--remove",function(){
+    $(this).parent().remove();
+  })
+
+})

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where("name LIKE(?)", "%#{params[:keyword]}%").limit(20)
+    @users = User.where("name LIKE(?)", "%#{params[:keyword]}%").where.not(id: current_user.id).limit(20)
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,13 @@
 class UsersController < ApplicationController
 
+  def index
+    @users = User.where("name LIKE(?)", "%#{params[:keyword]}%").limit(20)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -12,24 +12,29 @@
       = f.text_field :name, id: "chat_group_name", class: "chat-group-form__input",  placeholder: "グループ名を入力してください", type: "text", value: group.name
   .chat-group-form__field.clearfix
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
+  / .chat-group-form__field.clearfix
+  /   .chat-group-form__field--left
+  /     %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+  /   .chat-group-form__field--right
+  /     = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |b|
+  /       = b.label{ b.check_box + b.text }
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |b|
-        = b.label{ b.check_box + b.text }
-  .chat-group-form__field.clearfix
-    .chat-group-form__field--left
-    .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      .chat-group-users.js-add-user
+        - group.users.each do |user|
+          .chat-group-user.clearfix.js-chat-member
+            %input{name: 'group[user_ids][]', type: 'hidden', value: user.id }
+            %p.chat-group-user__name
+              = user.name
+            - if current_user.id != user.id
+              %a.user-search-add.chat-group-user__btn.chat-group-user__btn--remove{"data-user-id": user.id, "data-user-name": user.name} 削除
       = f.submit :submit, class: "chat-group-form__action-btn","data-disable-with" => "Save", name: "commit", type: "submit", value: "Save"

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.user_id user.id
+  json.user_name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root "groups#index"
-  resources :users,   only: [:update, :edit]
+  resources :users,   only: [:index, :update, :edit]
   resources :groups,  only: [:index , :new, :edit, :create, :update, :delete] do
     resources :messages,  only: [:index, :create]
   end


### PR DESCRIPTION
# WHAT
■全体感
・グループの作成、もしくは編集時においてメンバーとなるユーザーを検索をインクリメンタルサーチとした。
・サーチ結果の追加ボタンを押すと該当のユーザーはチャットメンバー欄に移動（検索結果から削除、メンバー欄に追加）する。
・チャットメンバーから外したいユーザーは削除ボタンを押すとメンバーから削除することができる。

■インクリメンタルサーチ　ユーザー検索と追加
https://i.gyazo.com/3f05940bf93711235845d3be709c3146.gif

■ユーザーの削除
https://i.gyazo.com/b63af1b40e53ec4224c8c3c20e41c835.gif

#WHY
グループのメンバー検索とユーザー登録の効率化のため